### PR TITLE
Minor change in pdb mapping code

### DIFF
--- a/mapping_sequence.py
+++ b/mapping_sequence.py
@@ -96,7 +96,7 @@ def reorder_atoms(mol_pdb_fname, mol_repeat_pdb, mol_match_pdb):
                         alt_loc_indicator=' ',
                         res_name="UNK",
                         chain_id='',
-                        res_seq_number=1,
+                        res_seq_number=idx,
                         insert_code=' ',
                         x= coordinates['x_cord'],
                         y= coordinates['y_cord'],


### PR DESCRIPTION
res_seq_number parameter has been changed. For gromacs gro file it wasn't an issue with same residue number but for openmm pdb must have different residue number.